### PR TITLE
Update link to Russian version of csscomb-core post

### DIFF
--- a/source/_posts/csscomb/csscomb-core.md
+++ b/source/_posts/csscomb/csscomb-core.md
@@ -2,7 +2,7 @@ title: "CSScomb Core: postprocessor in 15 mins"
 date: 2014/07/06
 id: "csscomb-core"
 show_in_footer: true
-translation: "ru/csscomb/csscomb-core"
+translation: "/ru/csscomb/csscomb-core"
 
 ---
 


### PR DESCRIPTION
Otherwise browsers go to `http://tonyganch.com/csscomb/csscomb-core/ru/csscomb/csscomb-core` instead of `http://tonyganch.com/ru/csscomb/csscomb-core`.